### PR TITLE
Remove return in case of function pointer

### DIFF
--- a/jbmc/src/janalyzer/janalyzer_parse_options.cpp
+++ b/jbmc/src/janalyzer/janalyzer_parse_options.cpp
@@ -634,7 +634,7 @@ bool janalyzer_parse_optionst::process_goto_program(const optionst &options)
     goto_partial_inline(goto_model, ui_message_handler);
 
     // remove returns, gcc vectors, complex
-    remove_returns(goto_model);
+    remove_returns(log.get_message_handler(), goto_model);
     remove_vector(goto_model);
     remove_complex(goto_model);
 

--- a/jbmc/src/jbmc/jbmc_parse_options.cpp
+++ b/jbmc/src/jbmc/jbmc_parse_options.cpp
@@ -838,7 +838,7 @@ void jbmc_parse_optionst::process_goto_function(
              !model.can_produce_function(id);
     };
 
-    remove_returns(function, function_is_stub);
+    remove_returns(get_message_handler(), function, function_is_stub);
 
     replace_java_nondet(function);
 

--- a/jbmc/src/jdiff/jdiff_parse_options.cpp
+++ b/jbmc/src/jdiff/jdiff_parse_options.cpp
@@ -296,7 +296,7 @@ bool jdiff_parse_optionst::process_goto_program(
     instrument_preconditions(goto_model);
 
     // remove returns, gcc vectors, complex
-    remove_returns(goto_model);
+    remove_returns(log.get_message_handler(), goto_model);
     remove_vector(goto_model);
     remove_complex(goto_model);
     rewrite_union(goto_model);

--- a/jbmc/unit/java_bytecode/java_replace_nondet/replace_nondet.cpp
+++ b/jbmc/unit/java_bytecode/java_replace_nondet/replace_nondet.cpp
@@ -154,7 +154,9 @@ void load_and_test_method(
   // Then test both situations.
   THEN("Replace nondet should work after remove returns has been called.")
   {
-    remove_returns(model_function, [](const irep_idt &) { return false; });
+    remove_returns(null_message_handler, model_function, [](const irep_idt &) {
+      return false;
+    });
 
     replace_java_nondet(model_function);
 
@@ -165,7 +167,9 @@ void load_and_test_method(
   {
     replace_java_nondet(model_function);
 
-    remove_returns(model_function, [](const irep_idt &) { return false; });
+    remove_returns(null_message_handler, model_function, [](const irep_idt &) {
+      return false;
+    });
 
     validate_nondet_method_removed(goto_function.body.instructions);
   }
@@ -176,7 +180,9 @@ void load_and_test_method(
     "Replace and convert nondet should work after remove returns has been "
     "called.")
   {
-    remove_returns(model_function, [](const irep_idt &) { return false; });
+    remove_returns(null_message_handler, model_function, [](const irep_idt &) {
+      return false;
+    });
 
     replace_java_nondet(model_function);
 
@@ -193,7 +199,9 @@ void load_and_test_method(
 
     convert_nondet(model_function, null_message_handler, params, ID_java);
 
-    remove_returns(model_function, [](const irep_idt &) { return false; });
+    remove_returns(null_message_handler, model_function, [](const irep_idt &) {
+      return false;
+    });
 
     validate_nondets_converted(goto_function.body.instructions);
   }

--- a/src/cbmc/cbmc_parse_options.cpp
+++ b/src/cbmc/cbmc_parse_options.cpp
@@ -814,7 +814,7 @@ bool cbmc_parse_optionst::process_goto_program(
     instrument_preconditions(goto_model);
 
     // remove returns, gcc vectors, complex
-    remove_returns(goto_model);
+    remove_returns(log.get_message_handler(), goto_model);
     remove_vector(goto_model);
     remove_complex(goto_model);
     rewrite_union(goto_model);

--- a/src/goto-analyzer/goto_analyzer_parse_options.cpp
+++ b/src/goto-analyzer/goto_analyzer_parse_options.cpp
@@ -688,7 +688,7 @@ bool goto_analyzer_parse_optionst::process_goto_program(
     goto_partial_inline(goto_model, ui_message_handler);
 
     // remove returns, gcc vectors, complex
-    remove_returns(goto_model);
+    remove_returns(log.get_message_handler(), goto_model);
     remove_vector(goto_model);
     remove_complex(goto_model);
 

--- a/src/goto-analyzer/static_simplifier.cpp
+++ b/src/goto-analyzer/static_simplifier.cpp
@@ -186,7 +186,7 @@ bool static_simplifier(
   }
 
   // restore return types before writing the binary
-  restore_returns(goto_model);
+  restore_returns(m.get_message_handler(), goto_model);
   goto_model.goto_functions.update();
 
   m.status() << "Writing goto binary" << messaget::eom;

--- a/src/goto-diff/goto_diff_parse_options.cpp
+++ b/src/goto-diff/goto_diff_parse_options.cpp
@@ -339,7 +339,7 @@ bool goto_diff_parse_optionst::process_goto_program(
     instrument_preconditions(goto_model);
 
     // remove returns, gcc vectors, complex
-    remove_returns(goto_model);
+    remove_returns(log.get_message_handler(), goto_model);
     remove_vector(goto_model);
     remove_complex(goto_model);
     rewrite_union(goto_model);

--- a/src/goto-instrument/goto_instrument_parse_options.cpp
+++ b/src/goto-instrument/goto_instrument_parse_options.cpp
@@ -651,7 +651,7 @@ int goto_instrument_parse_optionst::doit()
 
       // restore RETURN instructions in case remove_returns had been
       // applied
-      restore_returns(goto_model);
+      restore_returns(log.get_message_handler(), goto_model);
 
       if(cmdline.args.size()==2)
       {
@@ -906,7 +906,7 @@ void goto_instrument_parse_optionst::do_remove_returns()
   remove_returns_done=true;
 
   log.status() << "Removing returns" << messaget::eom;
-  remove_returns(goto_model);
+  remove_returns(log.get_message_handler(), goto_model);
 }
 
 void goto_instrument_parse_optionst::get_goto_program()

--- a/src/goto-programs/remove_function_pointers.cpp
+++ b/src/goto-programs/remove_function_pointers.cpp
@@ -419,95 +419,22 @@ void remove_function_pointerst::remove_function_pointer(
   const irep_idt &function_id,
   goto_programt::targett target)
 {
-  const code_function_callt &code = target->get_function_call();
+  goto_programt::const_targett const_target = target;
+  const auto candidates_pair =
+    get_function_pointer_targets(goto_program, const_target);
+  const auto &functions = candidates_pair.first;
+  const bool const_functions_removal_success = candidates_pair.second;
 
-  const auto &function = to_dereference_expr(code.function());
-
-  // this better have the right type
-  code_typet call_type=to_code_type(function.type());
-
-  // refine the type in case the forward declaration was incomplete
-  if(call_type.has_ellipsis() &&
-     call_type.parameters().empty())
+  if(const_functions_removal_success && functions.size() == 1)
   {
-    call_type.remove_ellipsis();
-    forall_expr(it, code.arguments())
-      call_type.parameters().push_back(
-        code_typet::parametert(it->type()));
+    auto call = target->get_function_call();
+    call.function() = *functions.cbegin();
+    target->set_function_call(call);
   }
-
-  bool found_functions;
-
-  const exprt &pointer = function.pointer();
-  remove_const_function_pointerst::functionst functions;
-  does_remove_constt const_removal_check(goto_program, ns);
-  const auto does_remove_const = const_removal_check();
-  if(does_remove_const.first)
+  else if(!const_functions_removal_success && !only_resolve_const_fps)
   {
-    log.warning().source_location = does_remove_const.second;
-    log.warning() << "cast from const to non-const pointer found, "
-                  << "only worst case function pointer removal will be done."
-                  << messaget::eom;
-    found_functions=false;
+    remove_function_pointer(goto_program, function_id, target, functions);
   }
-  else
-  {
-    remove_const_function_pointerst fpr(
-      log.get_message_handler(), ns, symbol_table);
-
-    found_functions=fpr(pointer, functions);
-
-    // if found_functions is false, functions should be empty
-    // however, it is possible for found_functions to be true and functions
-    // to be empty (this happens if the pointer can only resolve to the null
-    // pointer)
-    CHECK_RETURN(found_functions || functions.empty());
-
-    if(functions.size()==1)
-    {
-      auto call = target->get_function_call();
-      call.function() = *functions.cbegin();
-      target->set_function_call(call);
-      return;
-    }
-  }
-
-  if(!found_functions)
-  {
-    if(only_resolve_const_fps)
-    {
-      // If this mode is enabled, we only remove function pointers
-      // that we can resolve either to an exact function, or an exact subset
-      // (e.g. a variable index in a constant array).
-      // Since we haven't found functions, we would now resort to
-      // replacing the function pointer with any function with a valid signature
-      // Since we don't want to do that, we abort.
-      return;
-    }
-
-    bool return_value_used=code.lhs().is_not_nil();
-
-    // get all type-compatible functions
-    // whose address is ever taken
-    for(const auto &t : type_map)
-    {
-      // address taken?
-      if(address_taken.find(t.first)==address_taken.end())
-        continue;
-
-      // type-compatible?
-      if(!is_type_compatible(return_value_used, call_type, t.second))
-        continue;
-
-      if(t.first=="pthread_mutex_cleanup")
-        continue;
-
-      symbol_exprt expr(t.first, t.second);
-      functions.insert(expr);
-    }
-  }
-
-  remove_function_pointer(goto_program, function_id, target, functions);
 }
 
 void remove_function_pointerst::remove_function_pointer(

--- a/src/goto-programs/remove_function_pointers.cpp
+++ b/src/goto-programs/remove_function_pointers.cpp
@@ -46,6 +46,7 @@ public:
 
   // a set of function symbols
   using functionst = remove_const_function_pointerst::functionst;
+  using flagged_functionst = std::pair<functionst, bool>;
 
   /// Replace a call to a dynamic function at location
   /// target in the given goto-program by a case-split
@@ -59,6 +60,24 @@ public:
     const irep_idt &function_id,
     goto_programt::targett target,
     const functionst &functions);
+
+  /// Go through the whole model and find all potential function the pointer at
+  ///   \p call site may point to
+  /// \param goto_model: model to search for potential functions
+  /// \param call_site: the call site of the function pointer under analysis
+  /// \return the set of the potential functions
+  functionst get_function_pointer_targets(
+    const goto_modelt &goto_model,
+    goto_programt::const_targett &call_site);
+
+  ///Go through a single function body and find all potential function the
+  ///   pointer at \p call site may point to
+  /// \param goto_program: function body to search for potential functions
+  /// \param call_site: the call site of the function pointer under analysis
+  /// \return the set of the potential functions
+  flagged_functionst get_function_pointer_targets(
+    const goto_programt &goto_program,
+    goto_programt::const_targett &call_site);
 
 protected:
   messaget log;
@@ -104,6 +123,23 @@ protected:
     const irep_idt &in_function_id,
     code_function_callt &function_call,
     goto_programt &dest);
+
+  /// Refine the \p type in case the forward declaration was incomplete
+  /// \param type: the type to be refined
+  /// \param code: the function call code to get the arguments from
+  /// \return the refined call type
+  static code_typet
+  refine_call_type(const typet &type, const code_function_callt &code);
+
+  /// Try to remove the const function pointers
+  /// \param goto_program: the function body to run the const_removal_check on
+  /// \param functions: the list of functions the const removal found
+  /// \param pointer: the pointer to be resolved
+  /// \return true if the const removal is sufficient
+  bool try_remove_const_fp(
+    const goto_programt &goto_program,
+    functionst &functions,
+    const exprt &pointer);
 };
 
 remove_function_pointerst::remove_function_pointerst(
@@ -261,6 +297,121 @@ void remove_function_pointerst::fix_return_type(
 
   dest.add(goto_programt::make_assignment(
     code_assignt(old_lhs, typecast_exprt(tmp_symbol_expr, old_lhs.type()))));
+}
+
+code_typet remove_function_pointerst::refine_call_type(
+  const typet &type,
+  const code_function_callt &code)
+{
+  PRECONDITION(can_cast_type<code_typet>(type));
+  code_typet call_type = to_code_type(type);
+
+  if(call_type.has_ellipsis() && call_type.parameters().empty())
+  {
+    call_type.remove_ellipsis();
+    for(const auto &argument : code.arguments())
+      call_type.parameters().push_back(code_typet::parametert{argument.type()});
+  }
+  return call_type;
+}
+
+bool remove_function_pointerst::try_remove_const_fp(
+  const goto_programt &goto_program,
+  functionst &functions,
+  const exprt &pointer)
+{
+  PRECONDITION(functions.empty());
+
+  does_remove_constt const_removal_check(goto_program, ns);
+  const auto does_remove_const = const_removal_check();
+
+  if(does_remove_const.first)
+  {
+    log.warning().source_location = does_remove_const.second;
+    log.warning() << "cast from const to non-const pointer found, "
+                  << "only worst case function pointer removal will be done."
+                  << messaget::eom;
+    return true;
+  }
+  else
+  {
+    remove_const_function_pointerst fpr(
+      log.get_message_handler(), ns, symbol_table);
+
+    // if remove_const_function fails, functions should be empty
+    // however, it is possible for found_functions to be true and functions
+    // to be empty (this happens if the pointer can only resolve to the null
+    // pointer)
+    CHECK_RETURN(fpr(pointer, functions) || functions.empty());
+  }
+
+  // If this mode is enabled, we only remove function pointers
+  // that we can resolve either to an exact function, or an exact subset
+  // (e.g. a variable index in a constant array).
+  // Since we haven't found functions, we would now resort to
+  // replacing the function pointer with any function with a valid signature
+  // Since we don't want to do that, we abort.
+  return only_resolve_const_fps;
+}
+
+remove_function_pointerst::functionst
+remove_function_pointerst::get_function_pointer_targets(
+  const goto_modelt &goto_model,
+  goto_programt::const_targett &call_site)
+{
+  functionst functions;
+  for(const auto &function_pair : goto_model.goto_functions.function_map)
+  {
+    const auto &function_body = function_pair.second.body;
+    const auto &candidates_pair =
+      get_function_pointer_targets(function_body, call_site);
+    functions.insert(
+      candidates_pair.first.begin(), candidates_pair.first.end());
+  }
+  return functions;
+}
+
+remove_function_pointerst::flagged_functionst
+remove_function_pointerst::get_function_pointer_targets(
+  const goto_programt &goto_program,
+  goto_programt::const_targett &call_site)
+{
+  PRECONDITION(call_site->is_function_call());
+
+  const code_function_callt &code = call_site->get_function_call();
+  const auto &function = to_dereference_expr(code.function());
+  const auto &refined_call_type = refine_call_type(function.type(), code);
+
+  functionst functions;
+
+  bool const_removal_applied_and_is_the_only_one_allowed =
+    try_remove_const_fp(goto_program, functions, function.pointer());
+  if(const_removal_applied_and_is_the_only_one_allowed)
+    return {functions, true};
+
+  // get all type-compatible functions
+  // whose address is ever taken
+  for(const auto &type_pair : type_map)
+  {
+    const auto &candidate_function_name = type_pair.first;
+    const auto &candidate_function_type = type_pair.second;
+
+    // only accept as candidate functions such that:
+    // 1. their address was taken
+    // 2. their type is compatible with the call-site-function type
+    // 3. they're not pthread mutex clean-up
+    if(
+      address_taken.find(candidate_function_name) != address_taken.end() &&
+      is_type_compatible(
+        code.lhs().is_not_nil(), refined_call_type, candidate_function_type) &&
+      candidate_function_name != "pthread_mutex_cleanup")
+    {
+      functions.insert(
+        symbol_exprt{candidate_function_name, candidate_function_type});
+    }
+  }
+
+  return {functions, false};
 }
 
 void remove_function_pointerst::remove_function_pointer(
@@ -564,4 +715,36 @@ void remove_function_pointers(message_handlert &_message_handler,
     goto_model.goto_functions,
     add_safety_assertion,
     only_remove_const_fps);
+}
+
+possible_fp_targets_mapt get_function_pointer_targets(
+  message_handlert &message_handler,
+  goto_modelt &goto_model)
+{
+  remove_function_pointerst rfp(
+    message_handler,
+    goto_model.symbol_table,
+    false,
+    false,
+    goto_model.goto_functions);
+
+  possible_fp_targets_mapt target_map;
+  const auto &goto_functions = goto_model.goto_functions;
+  for(const auto &function_pair : goto_functions.function_map)
+  {
+    const auto &instructions = function_pair.second.body.instructions;
+    const auto &function_id = function_pair.first;
+    for(auto target = instructions.begin(); target != instructions.end();
+        target++)
+    {
+      if(
+        target->is_function_call() &&
+        target->get_function_call().function().id() == ID_dereference)
+      {
+        target_map.emplace(
+          function_id, rfp.get_function_pointer_targets(goto_model, target));
+      }
+    }
+  }
+  return target_map;
 }

--- a/src/goto-programs/remove_function_pointers.cpp
+++ b/src/goto-programs/remove_function_pointers.cpp
@@ -140,6 +140,16 @@ protected:
     const goto_programt &goto_program,
     functionst &functions,
     const exprt &pointer);
+
+  goto_programt build_new_code(
+    const functionst &functions,
+    const code_function_callt &code,
+    const irep_idt &function_id,
+    goto_programt::targett target);
+
+  void remove_function_pointer_log(
+    goto_programt::targett target,
+    const functionst &functions) const;
 };
 
 remove_function_pointerst::remove_function_pointerst(
@@ -444,75 +454,9 @@ void remove_function_pointerst::remove_function_pointer(
   const functionst &functions)
 {
   const code_function_callt &code = target->get_function_call();
-
   const exprt &function = code.function();
-  const exprt &pointer = to_dereference_expr(function).pointer();
 
-  // the final target is a skip
-  goto_programt final_skip;
-
-  goto_programt::targett t_final = final_skip.add(goto_programt::make_skip());
-
-  // build the calls and gotos
-
-  goto_programt new_code_calls;
-  goto_programt new_code_gotos;
-
-  for(const auto &fun : functions)
-  {
-    // call function
-    auto new_call = code;
-    new_call.function() = fun;
-
-    // the signature of the function might not match precisely
-    fix_argument_types(new_call);
-
-    goto_programt tmp;
-    fix_return_type(function_id, new_call, tmp);
-
-    auto call = new_code_calls.add(goto_programt::make_function_call(new_call));
-    new_code_calls.destructive_append(tmp);
-
-    // goto final
-    new_code_calls.add(goto_programt::make_goto(t_final, true_exprt()));
-
-    // goto to call
-    const address_of_exprt address_of(fun, pointer_type(fun.type()));
-
-    const auto casted_address =
-      typecast_exprt::conditional_cast(address_of, pointer.type());
-
-    new_code_gotos.add(
-      goto_programt::make_goto(call, equal_exprt(pointer, casted_address)));
-  }
-
-  // fall-through
-  if(add_safety_assertion)
-  {
-    goto_programt::targett t =
-      new_code_gotos.add(goto_programt::make_assertion(false_exprt()));
-    t->source_location.set_property_class("pointer dereference");
-    t->source_location.set_comment("invalid function pointer");
-  }
-
-  goto_programt new_code;
-
-  // patch them all together
-  new_code.destructive_append(new_code_gotos);
-  new_code.destructive_append(new_code_calls);
-  new_code.destructive_append(final_skip);
-
-  // set locations
-  Forall_goto_program_instructions(it, new_code)
-  {
-    irep_idt property_class=it->source_location.get_property_class();
-    irep_idt comment=it->source_location.get_comment();
-    it->source_location=target->source_location;
-    if(!property_class.empty())
-      it->source_location.set_property_class(property_class);
-    if(!comment.empty())
-      it->source_location.set_comment(comment);
-  }
+  goto_programt new_code = build_new_code(functions, code, function_id, target);
 
   goto_programt::targett next_target=target;
   next_target++;
@@ -527,27 +471,7 @@ void remove_function_pointerst::remove_function_pointer(
   target->type=OTHER;
 
   // report statistics
-  log.statistics().source_location = target->source_location;
-  log.statistics() << "replacing function pointer by " << functions.size()
-                   << " possible targets" << messaget::eom;
-
-  // list the names of functions when verbosity is at debug level
-  log.conditional_output(
-    log.debug(), [&functions](messaget::mstreamt &mstream) {
-      mstream << "targets: ";
-
-      bool first = true;
-      for(const auto &function : functions)
-      {
-        if(!first)
-          mstream << ", ";
-
-        mstream << function.get_identifier();
-        first = false;
-      }
-
-      mstream << messaget::eom;
-    });
+  remove_function_pointer_log(target, functions);
 }
 
 bool remove_function_pointerst::remove_function_pointers(
@@ -674,4 +598,101 @@ possible_fp_targets_mapt get_function_pointer_targets(
     }
   }
   return target_map;
+}
+
+goto_programt remove_function_pointerst::build_new_code(
+  const functionst &functions,
+  const code_function_callt &code,
+  const irep_idt &function_id,
+  goto_programt::targett target)
+{
+  // the final target is a skip
+  goto_programt final_skip;
+  const exprt &pointer = to_dereference_expr(code.function()).pointer();
+  goto_programt::targett t_final = final_skip.add(goto_programt::make_skip());
+
+  goto_programt new_code_calls;
+  goto_programt new_code_gotos;
+  for(const auto &function : functions)
+  {
+    // call function
+    auto new_call = code;
+
+    new_call.function() = function;
+
+    // the signature of the function might not match precisely
+    fix_argument_types(new_call);
+
+    goto_programt tmp;
+    fix_return_type(function_id, new_call, tmp);
+
+    auto call = new_code_calls.add(goto_programt::make_function_call(new_call));
+    new_code_calls.destructive_append(tmp);
+
+    // goto final
+    new_code_calls.add(goto_programt::make_goto(t_final, true_exprt{}));
+
+    // goto to call
+    const auto casted_address = typecast_exprt::conditional_cast(
+      address_of_exprt{function, pointer_type(function.type())},
+      pointer.type());
+
+    const auto goto_it = new_code_gotos.add(
+      goto_programt::make_goto(call, equal_exprt{pointer, casted_address}));
+
+    //set locations for the above goto
+    irep_idt property_class = goto_it->source_location.get_property_class();
+    irep_idt comment = goto_it->source_location.get_comment();
+    goto_it->source_location = target->source_location;
+    if(!property_class.empty())
+      goto_it->source_location.set_property_class(property_class);
+    if(!comment.empty())
+      goto_it->source_location.set_comment(comment);
+  }
+  //  return {std::move(new_code_calls), std::move(new_code_gotos)};
+
+  // fall-through
+  if(add_safety_assertion)
+  {
+    goto_programt::targett t =
+      new_code_gotos.add(goto_programt::make_assertion(false_exprt{}));
+    t->source_location.set_property_class("pointer dereference");
+    t->source_location.set_comment("invalid function pointer");
+  }
+
+  goto_programt new_code;
+
+  // patch them all together
+  new_code.destructive_append(new_code_gotos);
+  new_code.destructive_append(new_code_calls);
+  new_code.destructive_append(final_skip);
+
+  return new_code;
+}
+
+void remove_function_pointerst::remove_function_pointer_log(
+  goto_programt::targett target,
+  const functionst &functions) const
+{
+  log.statistics().source_location = target->source_location;
+  log.statistics() << "replacing function pointer by " << functions.size()
+                   << " possible targets" << messaget::eom;
+
+  // list the names of functions when verbosity is at debug level
+  log.conditional_output(
+    log.debug(), [&functions](messaget::mstreamt &mstream) {
+      mstream << "targets: ";
+
+      bool first = true;
+      for(const auto &function : functions)
+      {
+        if(!first)
+          mstream << ", ";
+
+        mstream << function.get_identifier();
+        first = false;
+      }
+
+      mstream << messaget::eom;
+    });
 }

--- a/src/goto-programs/remove_function_pointers.h
+++ b/src/goto-programs/remove_function_pointers.h
@@ -16,11 +16,22 @@ Date: June 2003
 
 #include <util/irep.h>
 
+#include <map>
+
+#include "remove_const_function_pointers.h"
+
 class goto_functionst;
 class goto_programt;
 class goto_modelt;
 class message_handlert;
 class symbol_tablet;
+
+using possible_fp_targetst = remove_const_function_pointerst::functionst;
+using possible_fp_targets_mapt = std::map<irep_idt, possible_fp_targetst>;
+
+possible_fp_targets_mapt get_function_pointer_targets(
+  message_handlert &message_handler,
+  goto_modelt &goto_model);
 
 // remove indirect function calls
 // and replace by case-split

--- a/src/goto-programs/remove_returns.cpp
+++ b/src/goto-programs/remove_returns.cpp
@@ -57,10 +57,19 @@ protected:
   optionalt<symbol_exprt>
   get_or_create_return_value_symbol(const irep_idt &function_id);
 
-  void do_function_call(
-    goto_programt::targett i_it,
-    goto_programt &goto_program,
-    bool is_stub);
+  /// Remove return of a complete function call
+  /// \param target: the function call instruction iterator
+  /// \param goto_program: the GOTO program to be updated
+  void do_function_call_complete(
+    goto_programt::targett target,
+    goto_programt &goto_program);
+
+  /// Remove return of a stub function call
+  /// \param target: the function call instruction iterator
+  /// \param goto_program: the GOTO program to be updated
+  void do_function_call_stub(
+    goto_programt::targett target,
+    goto_programt &goto_program);
 };
 
 optionalt<symbol_exprt>
@@ -153,7 +162,7 @@ bool remove_returnst::do_function_calls(
     if(!i_it->is_function_call())
       continue;
 
-    const auto &function_call = i_it->get_function_call();
+    code_function_callt function_call = i_it->get_function_call();
     INVARIANT(
       function_call.function().id() == ID_symbol,
       "indirect function calls should have been removed prior to running "
@@ -165,11 +174,18 @@ bool remove_returnst::do_function_calls(
       !function_call.lhs().is_not_nil())
       continue;
 
-    const auto &function_id =
-      to_symbol_expr(function_call.function()).get_identifier();
-    bool is_stub = function_is_stub(function_id);
+    if(function_is_stub(
+         to_symbol_expr(function_call.function()).get_identifier()))
+      do_function_call_stub(i_it, goto_program);
+    else
+      do_function_call_complete(i_it, goto_program);
 
-    do_function_call(i_it, goto_program, is_stub);
+    // fry the previous assignment
+    function_call.lhs().make_nil();
+
+    // update the call
+    i_it->set_function_call(function_call);
+
     requires_update = true;
   }
   return requires_update;
@@ -371,53 +387,47 @@ void restore_returns(goto_modelt &goto_model)
   rr.restore(goto_model.goto_functions);
 }
 
-void remove_returnst::do_function_call(
-  goto_programt::targett i_it,
-  goto_programt &goto_program,
-  bool is_stub)
+void remove_returnst::do_function_call_complete(
+  goto_programt::targett target,
+  goto_programt &goto_program)
 {
-  code_function_callt function_call = i_it->get_function_call();
-
-  const irep_idt function_id =
+  const auto &function_call = target->get_function_call();
+  const auto &function_id =
     to_symbol_expr(function_call.function()).get_identifier();
+
+  // The return type in the definition of the function may differ
+  // from the return type in the declaration.  We therefore do a
+  // cast.
+  optionalt<symbol_exprt> return_value =
+    get_or_create_return_value_symbol(function_id);
+  CHECK_RETURN(return_value.has_value());
 
   // replace "lhs=f(...)" by
   // "f(...); lhs=f#return_value; DEAD f#return_value;"
-  exprt rhs;
-
-  optionalt<symbol_exprt> return_value;
-
-  if(!is_stub)
-  {
-    return_value = get_or_create_return_value_symbol(function_id);
-    CHECK_RETURN(return_value.has_value());
-
-    // The return type in the definition of the function may differ
-    // from the return type in the declaration.  We therefore do a
-    // cast.
-    rhs = typecast_exprt::conditional_cast(
-      *return_value, function_call.lhs().type());
-  }
-  else
-  {
-    rhs = side_effect_expr_nondett(
-      function_call.lhs().type(), i_it->source_location);
-  }
-
   goto_programt::targett t_a = goto_program.insert_after(
-    i_it,
+    target,
     goto_programt::make_assignment(
-      code_assignt(function_call.lhs(), rhs), i_it->source_location));
+      code_assignt{function_call.lhs(),
+                   typecast_exprt::conditional_cast(
+                     *return_value, function_call.lhs().type())},
+      target->source_location));
 
-  // fry the previous assignment
-  function_call.lhs().make_nil();
+  goto_program.insert_after(
+    t_a, goto_programt::make_dead(*return_value, target->source_location));
+}
 
-  if(!is_stub)
-  {
-    goto_program.insert_after(
-      t_a, goto_programt::make_dead(*return_value, i_it->source_location));
-  }
+void remove_returnst::do_function_call_stub(
+  goto_programt::targett target,
+  goto_programt &goto_program)
+{
+  const auto &function_call = target->get_function_call();
 
-  // update the call
-  i_it->set_function_call(function_call);
+  // replace "lhs=f(...)" by "f(...); lhs=nondet;"
+  goto_program.insert_after(
+    target,
+    goto_programt::make_assignment(
+      code_assignt{function_call.lhs(),
+                   side_effect_expr_nondett{function_call.lhs().type(),
+                                            target->source_location}},
+      target->source_location));
 }

--- a/src/goto-programs/remove_returns.cpp
+++ b/src/goto-programs/remove_returns.cpp
@@ -57,10 +57,10 @@ protected:
   optionalt<symbol_exprt>
   get_or_create_return_value_symbol(const irep_idt &function_id);
 
-  bool do_function_call(
+  void do_function_call(
     goto_programt::targett i_it,
     goto_programt &goto_program,
-    function_is_stubt function_is_stub);
+    bool is_stub);
 };
 
 optionalt<symbol_exprt>
@@ -150,12 +150,27 @@ bool remove_returnst::do_function_calls(
 
   Forall_goto_program_instructions(i_it, goto_program)
   {
+    if(!i_it->is_function_call())
+      continue;
+
+    const auto &function_call = i_it->get_function_call();
+    INVARIANT(
+      function_call.function().id() == ID_symbol,
+      "indirect function calls should have been removed prior to running "
+      "remove-returns");
+    // Do we return anything?
     if(
-      i_it->is_function_call() &&
-      do_function_call(i_it, goto_program, function_is_stub))
-    {
-      requires_update = true;
-    }
+      to_code_type(function_call.function().type()).return_type() ==
+        empty_typet() ||
+      !function_call.lhs().is_not_nil())
+      continue;
+
+    const auto &function_id =
+      to_symbol_expr(function_call.function()).get_identifier();
+    bool is_stub = function_is_stub(function_id);
+
+    do_function_call(i_it, goto_program, is_stub);
+    requires_update = true;
   }
   return requires_update;
 }
@@ -356,70 +371,53 @@ void restore_returns(goto_modelt &goto_model)
   rr.restore(goto_model.goto_functions);
 }
 
-bool remove_returnst::do_function_call(
+void remove_returnst::do_function_call(
   goto_programt::targett i_it,
   goto_programt &goto_program,
-  function_is_stubt function_is_stub)
+  bool is_stub)
 {
   code_function_callt function_call = i_it->get_function_call();
-
-  INVARIANT(
-    function_call.function().id() == ID_symbol,
-    "indirect function calls should have been removed prior to running "
-    "remove-returns");
 
   const irep_idt function_id =
     to_symbol_expr(function_call.function()).get_identifier();
 
-  // Do we return anything?
-  if(
-    to_code_type(function_call.function().type()).return_type() !=
-      empty_typet() &&
-    function_call.lhs().is_not_nil())
+  // replace "lhs=f(...)" by
+  // "f(...); lhs=f#return_value; DEAD f#return_value;"
+  exprt rhs;
+
+  optionalt<symbol_exprt> return_value;
+
+  if(!is_stub)
   {
-    // replace "lhs=f(...)" by
-    // "f(...); lhs=f#return_value; DEAD f#return_value;"
+    return_value = get_or_create_return_value_symbol(function_id);
+    CHECK_RETURN(return_value.has_value());
 
-    exprt rhs;
-
-    bool is_stub = function_is_stub(function_id);
-    optionalt<symbol_exprt> return_value;
-
-    if(!is_stub)
-    {
-      return_value = get_or_create_return_value_symbol(function_id);
-      CHECK_RETURN(return_value.has_value());
-
-      // The return type in the definition of the function may differ
-      // from the return type in the declaration.  We therefore do a
-      // cast.
-      rhs = typecast_exprt::conditional_cast(
-        *return_value, function_call.lhs().type());
-    }
-    else
-    {
-      rhs = side_effect_expr_nondett(
-        function_call.lhs().type(), i_it->source_location);
-    }
-
-    goto_programt::targett t_a = goto_program.insert_after(
-      i_it,
-      goto_programt::make_assignment(
-        code_assignt(function_call.lhs(), rhs), i_it->source_location));
-
-    // fry the previous assignment
-    function_call.lhs().make_nil();
-
-    if(!is_stub)
-    {
-      goto_program.insert_after(
-        t_a, goto_programt::make_dead(*return_value, i_it->source_location));
-    }
-
-    // update the call
-    i_it->set_function_call(function_call);
-
-    return true;
+    // The return type in the definition of the function may differ
+    // from the return type in the declaration.  We therefore do a
+    // cast.
+    rhs = typecast_exprt::conditional_cast(
+      *return_value, function_call.lhs().type());
   }
-  return false;
+  else
+  {
+    rhs = side_effect_expr_nondett(
+      function_call.lhs().type(), i_it->source_location);
+  }
+
+  goto_programt::targett t_a = goto_program.insert_after(
+    i_it,
+    goto_programt::make_assignment(
+      code_assignt(function_call.lhs(), rhs), i_it->source_location));
+
+  // fry the previous assignment
+  function_call.lhs().make_nil();
+
+  if(!is_stub)
+  {
+    goto_program.insert_after(
+      t_a, goto_programt::make_dead(*return_value, i_it->source_location));
+  }
+
+  // update the call
+  i_it->set_function_call(function_call);
 }

--- a/src/goto-programs/remove_returns.cpp
+++ b/src/goto-programs/remove_returns.cpp
@@ -56,6 +56,11 @@ protected:
 
   optionalt<symbol_exprt>
   get_or_create_return_value_symbol(const irep_idt &function_id);
+
+  bool do_function_call(
+    goto_programt::targett i_it,
+    goto_programt &goto_program,
+    function_is_stubt function_is_stub);
 };
 
 optionalt<symbol_exprt>
@@ -145,72 +150,13 @@ bool remove_returnst::do_function_calls(
 
   Forall_goto_program_instructions(i_it, goto_program)
   {
-    if(i_it->is_function_call())
+    if(
+      i_it->is_function_call() &&
+      do_function_call(i_it, goto_program, function_is_stub))
     {
-      code_function_callt function_call = i_it->get_function_call();
-
-      INVARIANT(
-        function_call.function().id() == ID_symbol,
-        "indirect function calls should have been removed prior to running "
-        "remove-returns");
-
-      const irep_idt function_id =
-        to_symbol_expr(function_call.function()).get_identifier();
-
-      // Do we return anything?
-      if(
-        to_code_type(function_call.function().type()).return_type() !=
-          empty_typet() &&
-        function_call.lhs().is_not_nil())
-      {
-        // replace "lhs=f(...)" by
-        // "f(...); lhs=f#return_value; DEAD f#return_value;"
-
-        exprt rhs;
-
-        bool is_stub = function_is_stub(function_id);
-        optionalt<symbol_exprt> return_value;
-
-        if(!is_stub)
-        {
-          return_value = get_or_create_return_value_symbol(function_id);
-          CHECK_RETURN(return_value.has_value());
-
-          // The return type in the definition of the function may differ
-          // from the return type in the declaration.  We therefore do a
-          // cast.
-          rhs = typecast_exprt::conditional_cast(
-            *return_value, function_call.lhs().type());
-        }
-        else
-        {
-          rhs = side_effect_expr_nondett(
-            function_call.lhs().type(), i_it->source_location);
-        }
-
-        goto_programt::targett t_a = goto_program.insert_after(
-          i_it,
-          goto_programt::make_assignment(
-            code_assignt(function_call.lhs(), rhs), i_it->source_location));
-
-        // fry the previous assignment
-        function_call.lhs().make_nil();
-
-        if(!is_stub)
-        {
-          goto_program.insert_after(
-            t_a,
-            goto_programt::make_dead(*return_value, i_it->source_location));
-        }
-
-        // update the call
-        i_it->set_function_call(function_call);
-
-        requires_update = true;
-      }
+      requires_update = true;
     }
   }
-
   return requires_update;
 }
 
@@ -408,4 +354,72 @@ void restore_returns(goto_modelt &goto_model)
 {
   remove_returnst rr(goto_model.symbol_table);
   rr.restore(goto_model.goto_functions);
+}
+
+bool remove_returnst::do_function_call(
+  goto_programt::targett i_it,
+  goto_programt &goto_program,
+  function_is_stubt function_is_stub)
+{
+  code_function_callt function_call = i_it->get_function_call();
+
+  INVARIANT(
+    function_call.function().id() == ID_symbol,
+    "indirect function calls should have been removed prior to running "
+    "remove-returns");
+
+  const irep_idt function_id =
+    to_symbol_expr(function_call.function()).get_identifier();
+
+  // Do we return anything?
+  if(
+    to_code_type(function_call.function().type()).return_type() !=
+      empty_typet() &&
+    function_call.lhs().is_not_nil())
+  {
+    // replace "lhs=f(...)" by
+    // "f(...); lhs=f#return_value; DEAD f#return_value;"
+
+    exprt rhs;
+
+    bool is_stub = function_is_stub(function_id);
+    optionalt<symbol_exprt> return_value;
+
+    if(!is_stub)
+    {
+      return_value = get_or_create_return_value_symbol(function_id);
+      CHECK_RETURN(return_value.has_value());
+
+      // The return type in the definition of the function may differ
+      // from the return type in the declaration.  We therefore do a
+      // cast.
+      rhs = typecast_exprt::conditional_cast(
+        *return_value, function_call.lhs().type());
+    }
+    else
+    {
+      rhs = side_effect_expr_nondett(
+        function_call.lhs().type(), i_it->source_location);
+    }
+
+    goto_programt::targett t_a = goto_program.insert_after(
+      i_it,
+      goto_programt::make_assignment(
+        code_assignt(function_call.lhs(), rhs), i_it->source_location));
+
+    // fry the previous assignment
+    function_call.lhs().make_nil();
+
+    if(!is_stub)
+    {
+      goto_program.insert_after(
+        t_a, goto_programt::make_dead(*return_value, i_it->source_location));
+    }
+
+    // update the call
+    i_it->set_function_call(function_call);
+
+    return true;
+  }
+  return false;
 }

--- a/src/goto-programs/remove_returns.h
+++ b/src/goto-programs/remove_returns.h
@@ -73,6 +73,7 @@ Date:   September 2009
 
 #include <functional>
 
+#include <util/message.h>
 #include <util/std_types.h>
 
 #define RETURN_VALUE_SUFFIX "#return_value"
@@ -82,17 +83,23 @@ class goto_model_functiont;
 class goto_modelt;
 class symbol_table_baset;
 
-void remove_returns(symbol_table_baset &, goto_functionst &);
+void remove_returns(
+  message_handlert &m,
+  symbol_table_baset &,
+  goto_functionst &);
 
 typedef std::function<bool(const irep_idt &)> function_is_stubt;
 
-void remove_returns(goto_model_functiont &, function_is_stubt);
+void remove_returns(
+  message_handlert &m,
+  goto_model_functiont &,
+  function_is_stubt);
 
-void remove_returns(goto_modelt &);
+void remove_returns(message_handlert &m, goto_modelt &);
 
 // reverse the above operations
 void restore_returns(symbol_table_baset &, goto_functionst &);
 
-void restore_returns(goto_modelt &);
+void restore_returns(message_handlert &m, goto_modelt &);
 
 #endif // CPROVER_GOTO_PROGRAMS_REMOVE_RETURNS_H


### PR DESCRIPTION
Motivation: we want `remove_returns` to work even if not preceded by `remove_function_pointers`. For example:

```
int (* const fptbl2[])(void) = {g1, g2};

int func(int id1)
{
  t = fptbl2[id1];  // for this instruction the set is {"g1", "g2"}
  return t;
}
```
This PR exposes the function-pointer-target-collecting part of `remove_function_pointers` to be used in other analyses and the does so in `remove_returns`.

In `remove_returns` use the `possible_fp_targets_map` to be able to remove returns for calls to function pointers. `CALL x=*fp()` should become `CALL *fp(); ASSIGN x = (fp == &f00) ? return_value_f00 : (fp == &f01) ? ...`.

The first 3 commits are refactoring/preparation. The fourth introduces the interface. The fifth implements the new `do_function_call` for function pointers.

Then we refactor the `remove_function_pointers` to extract the collect-candidate-functions part and separate the modify-function-call part.

Finally -- now that the file is open -- we also refactor the internal `remove_function_pointers` without any functional change.

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
